### PR TITLE
Add webhook plugin

### DIFF
--- a/data/plugins/thirdparty/webhook.yaml
+++ b/data/plugins/thirdparty/webhook.yaml
@@ -1,0 +1,7 @@
+name: webhook
+repo: https://github.com/jkhsjdhjs/maubot-webhook
+license: AGPL-3.0-or-later
+author: jkhsjdhjs
+description: Send messages to rooms via user-defined webhooks.
+antifeatures: []
+public_instances: []


### PR DESCRIPTION
Hey,

I wrote this webhook plugin which allows sending messages via user-defined webhooks. A few features are Jinja2 templating, JSON support and authentication via Basic Auth and Token.

One thing I wasn't sure about is whether to list `Jinja2` as a dependency, since maubot itself already depends on it. However, it isn't explicitly listed as a dependency to not include [here](https://docs.mau.fi/maubot/dev/reference/plugin-metadata.html) and is also listed in a separate block in the [requirements of maubot](https://github.com/maubot/maubot/blob/a4253eceb24c65abba58bd3ada7d3d668f62b79c/requirements.txt), so I decided to just include it as a dependency.

If you have any additional feedback regarding the plugin itself I'd aprreciate it!