### PR TITLE
Add animemanga, choose

### DIFF
--- a/data/plugins/thirdparty/animemanga.yaml
+++ b/data/plugins/thirdparty/animemanga.yaml
@@ -1,0 +1,6 @@
+name: animemanga
+repo: https://github.com/coffeebank/coffee-maubot/tree/master/animemanga
+license: AGPL-3.0-or-later
+author: coffeebank
+description: Search anime, manga (manhwa/manhua), and light novels from Anilist. See series info, status, and episodes/chapters.
+public_instances: []

--- a/data/plugins/thirdparty/choose.yaml
+++ b/data/plugins/thirdparty/choose.yaml
@@ -1,0 +1,6 @@
+name: choose
+repo: https://github.com/coffeebank/coffee-maubot/tree/master/choose
+license: AGPL-3.0-or-later
+author: coffeebank
+description: Have the bot choose for you ( item1 | item2 | item3 ) with a divider
+public_instances: []


### PR DESCRIPTION
## animanga

A bot that can:
- Search anime, manga (manhwa/manhua), and light novels from Anilist.
- See series info, status, and episodes/chapters.

Readme: https://github.com/coffeebank/coffee-maubot/tree/master/animemanga

## choose

Have the bot choose for you: `!choose item1 | item2 | item3`

Readme: https://github.com/coffeebank/coffee-maubot/tree/master/choose