### PR TITLE
Add timein, send-custom-html, jadict plugins

### DIFF
--- a/data/plugins/thirdparty/jadict.yaml
+++ b/data/plugins/thirdparty/jadict.yaml
@@ -1,0 +1,6 @@
+name: jadict
+repo: https://github.com/coffeebank/coffee-maubot/tree/master/jadict
+license: AGPL-3.0-or-later
+author: coffeebank
+description: A Japanese dictionary Matrix bot for searching and translating Japanese vocabulary (Hiragana, Katakana, Kanji, Romaji). Searches Jisho using Jisho API.
+public_instances: []

--- a/data/plugins/thirdparty/send-custom-html.yaml
+++ b/data/plugins/thirdparty/send-custom-html.yaml
@@ -1,0 +1,6 @@
+name: send-custom-html
+repo: https://github.com/coffeebank/coffee-maubot/tree/master/send-custom-html
+license: AGPL-3.0-or-later
+author: coffeebank
+description: Have the bot send a message as custom HTML. Test and preview formatted HTML body in Matrix.
+public_instances: []

--- a/data/plugins/thirdparty/timein.yaml
+++ b/data/plugins/thirdparty/timein.yaml
@@ -1,0 +1,6 @@
+name: timein
+repo: https://github.com/coffeebank/coffee-maubot/tree/master/timein
+license: AGPL-3.0-or-later
+author: coffeebank
+description: Get the time in specific cities. Check timezones.  !timein New York  (Python 3.9+) (Python <3.9 requires pytz, fuzzywuzzy)
+public_instances: []


### PR DESCRIPTION
## timein
Get the time in specific cities. Check timezones.  !timein New York  (Python 3.9+) (Python <3.9 requires pytz, fuzzywuzzy)
- [README >](https://github.com/coffeebank/coffee-maubot/tree/master/timein)

## send-custom-html
Have the bot send a message as custom HTML. Test and preview formatted HTML body in Matrix.
- [README >](https://github.com/coffeebank/coffee-maubot/tree/master/send-custom-html)

## jadict
A Japanese dictionary Matrix bot for searching and translating Japanese vocabulary (Hiragana, Katakana, Kanji, Romaji). Searches Jisho using Jisho API.
- [README >](https://github.com/coffeebank/coffee-maubot/tree/master/jadict)