### PR TITLE
Add the timer plugin to the list

### DIFF
--- a/data/plugins/thirdparty/timer.yaml
+++ b/data/plugins/thirdparty/timer.yaml
@@ -1,0 +1,16 @@
+# The name of the plugin.
+name: timer
+# A link to the Git repository.
+repo: https://github.com/pedantic-git/maubot-timer
+# The SPDX license identifier for the plugin (same as in maubot.yaml)
+license: MIT
+# The author of the plugin.
+author: pedantic-git
+# A short description for the plugin. May contain markdown.
+description: Start a countdown timer for the specified number of seconds
+# Antifeature identifiers. Currently the only defined value is `synchronous`,
+# which must be included if the plugin uses non-async libraries in the main
+# thread (because that can block the whole maubot process).
+antifeatures: []
+# List of public bot user IDs where the plugin is running.
+public_instances: []


### PR DESCRIPTION
I just spent a couple of hours creating a 'timer' plugin that uses `asyncio.sleep` to wait for the specified number of seconds and then issue a response with "Time's up!"

This is my first time writing a Maubot plugin and also my Python is a little rusty, so I'd love a little look over the sources if you have chance. They're here: https://github.com/pedantic-git/maubot-timer

Thanks so much for this amazing bot! I'm loving how modular it is!