### PR TITLE
added reacjibot

### DIFF
--- a/data/plugins/thirdparty/reacji.yaml
+++ b/data/plugins/thirdparty/reacji.yaml
@@ -1,0 +1,16 @@
+# The name of the plugin.
+name: ReacjiBot
+# A link to the Git repository.
+repo: https://github.com/ajkessel/reacjibot
+# The SPDX license identifier for the plugin (same as in maubot.yaml)
+license: MIT
+# The author of the plugin.
+author: Adam Kessel
+# A short description for the plugin. May contain markdown.
+description: Allows users to define emoji-reactions that cause messages to be cross-posted to arbitrary rooms
+# Antifeature identifiers. Currently the only defined value is `synchronous`,
+# which must be included if the plugin uses non-async libraries in the main
+# thread (because that can block the whole maubot process).
+antifeatures: []
+# List of public bot user IDs where the plugin is running.
+public_instances: []


### PR DESCRIPTION
added info for reacjibot, a Maubot plugin that allows users to use emoji-reactions to cross-post messages to arbitrary rooms