### PR TITLE
Add gemini chatbot plugin

### DIFF
--- a/data/plugins/thirdparty/gemini.yaml
+++ b/data/plugins/thirdparty/gemini.yaml
@@ -1,0 +1,6 @@
+name: gemini
+repo: https://github.com/shanks219/maubot-gemini-bot/
+license: MIT
+author: Shanks
+description: A simple gemini-pro chatbot.
+public_instances: []


### PR DESCRIPTION
Add a single gemini chatbot plugin. It needs Langchain python library.