### PR TITLE
Add kodict plugin ; Update animemanga, timein plugins

### DIFF
--- a/data/plugins/thirdparty/animemanga.yaml
+++ b/data/plugins/thirdparty/animemanga.yaml
@@ -2,5 +2,5 @@ name: animemanga
 repo: https://github.com/coffeebank/coffee-maubot/tree/master/animemanga
 license: AGPL-3.0-or-later
 author: coffeebank
-description: An anime/manga bot for Matrix. Search anime, manga (manhwa/manhua), and light novels from Anilist. See series info, status, and episodes/chapters.
+description: An anime/manga bot for Matrix. Search anime, manga (manhwa/manhua), and light novels. See series info, status, episodes/chapters, and tags. Search Anilist, MangaDex, and Batoto.
 public_instances: []

--- a/data/plugins/thirdparty/kodict.yaml
+++ b/data/plugins/thirdparty/kodict.yaml
@@ -1,0 +1,6 @@
+name: kodict
+repo: https://github.com/coffeebank/coffee-maubot/tree/master/kodict
+license: AGPL-3.0-or-later
+author: coffeebank
+description: A Korean dictionary Matrix bot for searching and translating Korean vocabulary (Hangul/Hangeul, Hanja). Searches National Institute of Korean Language's Korean-English Learners' Dictionary (한국어기초사전).
+public_instances: []

--- a/data/plugins/thirdparty/timein.yaml
+++ b/data/plugins/thirdparty/timein.yaml
@@ -2,5 +2,5 @@ name: timein
 repo: https://github.com/coffeebank/coffee-maubot/tree/master/timein
 license: AGPL-3.0-or-later
 author: coffeebank
-description: Get the time in specific cities. Check timezones.  !timein New York  (Python 3.9+) (Python <3.9 requires pytz, fuzzywuzzy)
+description: Get the time in specific cities. Check timezones.  !timein America/New_York  (Python 3.9+)
 public_instances: []


### PR DESCRIPTION
## kodict
A Korean dictionary Matrix bot for searching and translating Korean vocabulary (Hangul/Hangeul, Hanja). Searches National Institute of Korean Language's Korean-English Learners' Dictionary (한국어기초사전).
- [README >](https://github.com/coffeebank/coffee-maubot/tree/master/kodict)
- Note: Requires dependencies (See README for details)

## animemanga - Updated
Updated description to include new sources
- [README >](https://github.com/coffeebank/coffee-maubot/tree/master/animemanga)

## timein - Updated
Updated description to hide outdated Python <3.8
- [README >](https://github.com/coffeebank/coffee-maubot/tree/master/timein)
