### PR TITLE
Add two plugins

### DIFF
--- a/data/plugins/thirdparty/maubot-stt
+++ b/data/plugins/thirdparty/maubot-stt
@@ -1,0 +1,6 @@
+name:maubot-stt
+repo:https://github.com/code-gal/maubot-reactbot
+license:MIT License
+author:coder-gal
+description:Transcriptions of audio messages to text in Matrix clients using OpenAI's Whisper API
+public_instances: []

--- a/data/plugins/thirdparty/maubot-webdownload
+++ b/data/plugins/thirdparty/maubot-webdownload
@@ -1,0 +1,6 @@
+name:maubot-webdownload
+repo:https://github.com/code-gal/maubot-webdownload
+license:GNU LESSER GENERAL PUBLIC LICENSE Version 3
+author:coder-gal
+description:fork from matrix-url-download add some features.A plugin for the maubot bot framework implementing URL downloads in matrix rooms.
+public_instances: []


### PR DESCRIPTION
maubot-stt: Transcriptions of audio messages to text in Matrix clients using OpenAI's Whisper API
maubot-webdownload: fork from matrix-url-download, add some features.A plugin for the maubot bot framework implementing URL downloads in matrix rooms.