### PR TITLE
add llmplus plugin

### DIFF
--- a/.idea/.gitignore
+++ b/.idea/.gitignore
@@ -1,0 +1,8 @@
+# Default ignored files
+/shelf/
+/workspace.xml
+# Editor-based HTTP Client requests
+/httpRequests/
+# Datasource local storage ignored files
+/dataSources/
+/dataSources.local.xml

--- a/.idea/.gitignore
+++ b/.idea/.gitignore
@@ -1,8 +1,0 @@
-# Default ignored files
-/shelf/
-/workspace.xml
-# Editor-based HTTP Client requests
-/httpRequests/
-# Datasource local storage ignored files
-/dataSources/
-/dataSources.local.xml

--- a/data/plugins/thirdparty/llmplus.yaml
+++ b/data/plugins/thirdparty/llmplus.yaml
@@ -1,0 +1,16 @@
+# The name of the plugin.
+name: llmplus
+# A link to the Git repository.
+repo: https://github.com/smallThank/maubot-llmplus.git
+# The SPDX license identifier for the plugin (same as in maubot.yaml)
+license: MIT
+# The author of the plugin.
+author: Taylorxie
+# A short description for the plugin. May contain markdown.
+description: you can call ai platform(local ai service(ollama, lmstudio), openai, anthropic) in bot
+# Antifeature identifiers. Currently the only defined value is `synchronous`,
+# which must be included if the plugin uses non-async libraries in the main
+# thread (because that can block the whole maubot process).
+antifeatures: []
+# List of public bot user IDs where the plugin is running.
+public_instances: []


### PR DESCRIPTION
I have added the AI LLM multiple bot plugin, which integrates Ollama, LMStudio, OpenAI, and Anthropic, allowing the bot to use AI models through these platforms.