### PR TITLE
announcement

### DIFF
--- a/data/plugins/thirdparty/annoucement.yaml
+++ b/data/plugins/thirdparty/annoucement.yaml
@@ -1,0 +1,7 @@
+name: maubot-announcement
+repo: https://github.com/toshanmugaraj/maubot-announcement.git
+license:  MIT
+author: shunmugaraj subramanian
+description: This bot is used to send anonymous messages to users similar to server notices but with more custom option
+antifeatures: []
+public_instances: []

--- a/data/plugins/thirdparty/annoucement.yaml
+++ b/data/plugins/thirdparty/annoucement.yaml
@@ -1,6 +1,6 @@
 name: maubot-announcement
 repo: https://github.com/toshanmugaraj/maubot-announcement.git
-license:  MIT
+license:  CC-BY-SA-4.0
 author: shunmugaraj subramanian
 description: This bot is used to send anonymous messages to users similar to server notices but with more custom option
 antifeatures: []


### PR DESCRIPTION
This bot allows users to send announcement messages from one room to multiple other users as 1 to 1 private chat room. This bot is used to send anonymous messages to users similar to server notices but with more custom option.