### PR TITLE
Add DuckDuckGo search plugin

### DIFF
--- a/data/plugins/thirdparty/duckduckgo.yaml
+++ b/data/plugins/thirdparty/duckduckgo.yaml
@@ -1,0 +1,6 @@
+name: duckduckgo
+repo: https://gitlab.com/avedor-projects/matrix/maubot-ddg
+license: MIT
+author: Avery Dorgan
+description: A Maubot plugin for querying DuckDuckGo's API and returning search results
+public_instances: []


### PR DESCRIPTION
A simple plugin to make calls to the DuckDuckGo Instant Answer API from within Matrix