### PR TITLE
Add plugin for home assistant conversation

### DIFF
--- a/data/plugins/thirdparty/homeassistant.yaml
+++ b/data/plugins/thirdparty/homeassistant.yaml
@@ -1,0 +1,6 @@
+name: homeassistant
+repo: https://gitlab.com/avedor-projects/matrix/maubot-home-assistant
+license: MIT
+author: Avery Dorgan
+description: A Maubot plugin for interacting with Home Assistant's Conversation API
+public_instances: []


### PR DESCRIPTION
A simple plugin to make calls to Home Assistant's Conversation API from within Matrix