### PR TITLE
Add Ticket Bot plugin entry

### DIFF
--- a/data/plugins/thirdparty/ticketbot.yaml
+++ b/data/plugins/thirdparty/ticketbot.yaml
@@ -1,0 +1,17 @@
+# The name of the plugin.
+
+name: Ticket Bot
+repo: https://github.com/Musfira89/Ticket-Bot-System
+
+license: MIT
+author: Musfira Ansari
+description:
+ A simple Matrix support ticketing system powered by Maubot.
+  - Users can open tickets by category (general, purchase, other).
+  - Each ticket creates a private room with the user and admin.
+  - Tickets auto-close and delete after 14 days.
+  - Unauthorized/banned bots are kicked automatically.
+
+antifeatures: []
+# List of public bot user IDs where the plugin is running.
+public_instances: []


### PR DESCRIPTION
This PR adds a new Ticket Bot plugin to the Maubot plugin index.

Repo: https://github.com/Musfira89/Ticket-Bot-System
License: MIT
Author: Musfira Ansari

Features:
- Ticket categories (general, purchase, other)
- Auto-close and delete after 14 days
- Admin invite enforcement
- SQLite persistence for open tickets
- Unauthorized/banned bots are auto-kicked
