### PR TITLE
Adding Jitsi-Meet maubot plugin

### DIFF
--- a/data/plugins/thirdparty/jitsi-meet.yaml
+++ b/data/plugins/thirdparty/jitsi-meet.yaml
@@ -1,0 +1,16 @@
+# The name of the plugin.
+name: jitsi-meet
+# A link to the Git repository.
+repo: https://codeberg.org/futurematt/maubot-jitsimeet
+# The SPDX license identifier for the plugin (same as in maubot.yaml)
+license: GPL-3.0-or-later
+# The author of the plugin.
+author: futurematt
+# A short description for the plugin. May contain markdown.
+description: A maubot plugin that creates and manages Jitsi Meet video calls in Matrix rooms, making calling simple for any Matrix client.
+# Antifeature identifiers. Currently the only defined value is `synchronous`,
+# which must be included if the plugin uses non-async libraries in the main
+# thread (because that can block the whole maubot process).
+antifeatures: []
+# List of public bot user IDs where the plugin is running.
+public_instances: []


### PR DESCRIPTION
Adding [Jitsi-Meet plugin](https://codeberg.org/futurematt/maubot-jitsimeet)
A maubot plugin that creates and manages Jitsi Meet video calls in Matrix rooms, making calling simple for any Matrix client.