### PR TITLE
Update toonbot description to remove defunct 'Master of Science' website

### DIFF
--- a/data/plugins/thirdparty/memegen.yaml
+++ b/data/plugins/thirdparty/memegen.yaml
@@ -1,0 +1,7 @@
+name: memegen
+repo: https://github.com/snex/memegen
+license: MIT
+author: Dave Havlicek (snex)
+description: Bot that lets users auto-generate memes through memegen.link
+antifeatures: []
+public_instances: []

--- a/data/plugins/thirdparty/toonbot.yaml
+++ b/data/plugins/thirdparty/toonbot.yaml
@@ -1,0 +1,7 @@
+name: toonbot
+repo: https://github.com/snex/toonbot
+license: MIT
+author: Dave Havlicek (snex)
+description: Bot that provides frames from Frinkiac, Morbotron and Master of Science
+antifeatures: []
+public_instances: []


### PR DESCRIPTION
Master of Science was shut down, so it was removed from toonbot.